### PR TITLE
FEATURE(Linux): Make the abi_stable poc work for Ubuntu

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,10 @@ members = [
     "crates/go-types", 
     "crates/kernel", 
     "crates/plugin_interface", 
-    "crates/plugins/plugin1",
-    "crates/plugins/plugin2"
+    "crates/plugins/parse_file/iface",
+    "crates/plugins/parse_file/libimpl",
+    "crates/plugins/count_funcs/iface",
+    "crates/plugins/count_funcs/libimpl"
 ]
 
 [dependencies.abi_stable]

--- a/build_plugins.sh
+++ b/build_plugins.sh
@@ -2,13 +2,20 @@
 set -euo pipefail
 source .envrc
 
-PLUGINS_DIR="$HOME/.cargo/skanujkod-plugins"
-mkdir "$PLUGINS_DIR" 2>/dev/null || true
+case $(uname -s) in
+    Linux*)     DYNLIB_SUFFIX=".so";;
+    Darwin*)    DYNLIB_SUFFIX=".dylib";;
+esac
 
-for item in crates/plugins/*; do
+PLUGINS_DIR="$HOME/.cargo/skanujkod-plugins"
+mkdir -p "$PLUGINS_DIR" 2>/dev/null || true
+
+pushd "crates/plugins"
+for item in *; do
     pushd "$item"
     cargo build
     popd
+    cp "../../target/debug/lib"${item}"_plugin"${DYNLIB_SUFFIX} "$PLUGINS_DIR/"
 done
+popd
 
-cp target/debug/*.dylib "$PLUGINS_DIR/"

--- a/crates/plugins/count_funcs/iface/Cargo.toml
+++ b/crates/plugins/count_funcs/iface/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "count_funcs_plugin"
+version = "0.1.0"
+authors = ["rodrimati1992 <rodrimatt1985@gmail.com>"]
+edition = "2024"
+
+[lib]
+name = "count_funcs_plugin"
+crate-type = ["cdylib"]
+
+[dependencies.abi_stable]
+# git = "https://github.com/kidq330/abi_stable.git"
+# branch = "waive_executable_identity"
+git = "https://github.com/rodrimati1992/abi_stable_crates.git"
+
+[dependencies.plugin_interface]
+path = "../../../plugin_interface"
+features = ["impls"]
+
+[dependencies.parse_file_lib]
+path = "../../parse_file/libimpl"
+
+[dependencies.count_funcs_lib]
+path = "../libimpl"

--- a/crates/plugins/count_funcs/iface/src/lib.rs
+++ b/crates/plugins/count_funcs/iface/src/lib.rs
@@ -1,9 +1,10 @@
 use abi_stable::{rvec, std_types::RVec};
+use count_funcs_lib::{CountFuncsDeps, CountFuncsParams};
+use parse_file_lib::ParseFileResult;
 use plugin_interface::{
     BoxedPFResult, PFConnector, PFDependencies, PFType, Plugin, Plugin_Ref, PluginFunction,
     QualPFID, UserParameters,
 };
-use plugin1::ParseResult;
 
 use abi_stable::{DynTrait, export_root_module, prefix_type::PrefixTypeTrait, sabi_extern_fn};
 
@@ -18,13 +19,13 @@ fn new_pf_vec2() -> RVec<PFConnector> {
         pf: PluginFunction(new_pf2),
         pf_type: PFType {
             pf_dependencies: rvec![QualPFID {
-                plugin_id: "plugin1".into(),
+                plugin_id: "parse_file_plugin".into(),
                 pf_id: "parse_file".into()
             }],
             user_params: rvec![]
         },
         pf_id: QualPFID {
-            plugin_id: "plugin2".into(),
+            plugin_id: "count_funcs_plugin".into(),
             pf_id: "count_funcs".into()
         }
     }]
@@ -39,21 +40,16 @@ fn new_pf2(pf_results: PFDependencies, user_params: &UserParameters) -> BoxedPFR
 
     let boxed_parse_result = pf_results
         .get(&QualPFID {
-            plugin_id: "plugin1".into(),
+            plugin_id: "parse_file_plugin".into(),
             pf_id: "parse_file".into(),
         })
         .unwrap();
-    let parse_result = unsafe { boxed_parse_result.unchecked_downcast_as::<ParseResult>() };
-    let count_res = count_funcs(&parse_result.file);
+    let parse_file_result =
+        unsafe { boxed_parse_result.unchecked_downcast_as::<ParseFileResult>() };
+
+    let count_res =
+        count_funcs_lib::count_funcs(CountFuncsDeps { parse_file_result }, CountFuncsParams {});
     dbg!(count_res);
 
     DynTrait::from_value(count_res)
-}
-
-fn count_funcs(file: &go_parser::ast::File) -> u32 {
-    file.decls
-        .iter()
-        .filter(|decl| matches!(decl, go_parser::ast::Decl::Func(_)))
-        .map(|_| 1)
-        .sum()
 }

--- a/crates/plugins/count_funcs/libimpl/Cargo.toml
+++ b/crates/plugins/count_funcs/libimpl/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "plugin2"
+name = "count_funcs_lib"
 version = "0.1.0"
 authors = ["rodrimati1992 <rodrimatt1985@gmail.com>"]
 edition = "2024"
 
 [lib]
-name = "plugin2"
+name = "count_funcs_lib"
 crate-type = ["lib", "cdylib"]
 
 [dependencies.abi_stable]
@@ -14,11 +14,11 @@ crate-type = ["lib", "cdylib"]
 git = "https://github.com/rodrimati1992/abi_stable_crates.git"
 
 [dependencies.plugin_interface]
-path = "../../plugin_interface"
+path = "../../../plugin_interface"
 features = ["impls"]
 
 [dependencies.go-parser]
-path = "../../go-parser"
+path = "../../../go-parser"
 
-[dependencies.plugin1]
-path = "../plugin1"
+[dependencies.parse_file_lib]
+path = "../../parse_file/libimpl"

--- a/crates/plugins/count_funcs/libimpl/src/lib.rs
+++ b/crates/plugins/count_funcs/libimpl/src/lib.rs
@@ -1,0 +1,19 @@
+pub type CountFuncsResult = u32;
+
+pub struct CountFuncsDeps<'a> {
+    pub parse_file_result: &'a parse_file_lib::ParseFileResult,
+}
+
+pub struct CountFuncsParams {}
+
+pub fn count_funcs(deps: CountFuncsDeps, _params: CountFuncsParams) -> CountFuncsResult {
+    count_funcs_priv(&deps.parse_file_result.file)
+}
+
+fn count_funcs_priv(file: &go_parser::ast::File) -> u32 {
+    file.decls
+        .iter()
+        .filter(|decl| matches!(decl, go_parser::ast::Decl::Func(_)))
+        .map(|_| 1)
+        .sum()
+}

--- a/crates/plugins/parse_file/iface/Cargo.toml
+++ b/crates/plugins/parse_file/iface/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "plugin1"
+name = "parse_file_plugin"
 version = "0.1.0"
 authors = ["rodrimati1992 <rodrimatt1985@gmail.com>"]
 edition = "2024"
 
 [lib]
-name = "plugin1"
-crate-type = ["lib", "cdylib"]
+name = "parse_file_plugin"
+crate-type=["cdylib"]
 
 [dependencies.abi_stable]
 # git = "https://github.com/kidq330/abi_stable.git"
@@ -15,8 +15,8 @@ git = "https://github.com/rodrimati1992/abi_stable_crates.git"
 
 
 [dependencies.plugin_interface]
-path = "../../plugin_interface"
+path = "../../../plugin_interface"
 features = ["impls"]
 
-[dependencies.go-parser]
-path = "../../go-parser"
+[dependencies.parse_file_lib]
+path = "../libimpl"

--- a/crates/plugins/parse_file/libimpl/Cargo.toml
+++ b/crates/plugins/parse_file/libimpl/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "parse_file_lib"
+version = "0.1.0"
+authors = ["rodrimati1992 <rodrimatt1985@gmail.com>"]
+edition = "2024"
+
+[lib]
+name = "parse_file_lib"
+crate-type = ["lib", "cdylib"]
+
+[dependencies.abi_stable]
+# git = "https://github.com/kidq330/abi_stable.git"
+# branch = "waive_executable_identity"
+git = "https://github.com/rodrimati1992/abi_stable_crates.git"
+
+
+[dependencies.plugin_interface]
+path = "../../../plugin_interface"
+features = ["impls"]
+
+[dependencies.go-parser]
+path = "../../../go-parser"

--- a/crates/plugins/parse_file/libimpl/src/lib.rs
+++ b/crates/plugins/parse_file/libimpl/src/lib.rs
@@ -1,0 +1,37 @@
+use abi_stable::std_types::RString;
+use std::fmt::{self, Display};
+
+#[derive(Debug)]
+pub struct ParseFileResult {
+    pub file: go_parser::ast::File,
+    pub ast_objects: go_parser::AstObjects,
+}
+
+impl Display for ParseFileResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&0, f)
+    }
+}
+
+pub struct ParseFileDep {}
+
+pub struct ParseFileParams {
+    pub filepath: RString,
+}
+
+pub fn parse_file(_deps: ParseFileDep, params: &ParseFileParams) -> ParseFileResult {
+    let source =
+        std::fs::read_to_string(params.filepath.as_str()).expect("Failed to open go source file");
+
+    let mut fs = go_parser::FileSet::new();
+    let mut o = go_parser::AstObjects::new();
+    let el = &mut go_parser::ErrorList::new();
+
+    let (_parser, maybe_file) =
+        go_parser::parse_file(&mut o, &mut fs, el, params.filepath.as_str(), &source, true);
+
+    ParseFileResult {
+        file: maybe_file.expect("Something went wrong when trying to parse the source"),
+        ast_objects: o,
+    }
+}


### PR DESCRIPTION
[un?]surprisingly the Linux ABI has a problem with cdylibs as dependencies when loading the libraries, and crashes with a duplicate symbol error, due to two root modules being in the namespace, probably. To work around this for now, each plugin unfortunately has to be split into an implementation part and a interface/glue part